### PR TITLE
fix(ci): repair lychee, devcontainer GHCR push, renovate lookups

### DIFF
--- a/.devcontainer/ci/Dockerfile
+++ b/.devcontainer/ci/Dockerfile
@@ -1,2 +1,4 @@
 # Ref: https://github.com/devcontainers/ci/issues/191
 FROM mcr.microsoft.com/devcontainers/base:alpine
+# Keep package linked to this repo for free GITHUB_TOKEN GHCR publishes.
+LABEL org.opencontainers.image.source="https://github.com/scottking2/home-ops"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,18 @@
   packageRules: [
     {
       description: [
+        'Private self-published GHCR image; Renovate cannot look up tags without package credentials',
+      ],
+      matchDatasources: [
+        'docker',
+      ],
+      enabled: false,
+      matchPackageNames: [
+        'ghcr.io/scottking2/vrm-mqtt-bridge',
+      ],
+    },
+    {
+      description: [
         'Loose versioning for non-semver packages',
       ],
       matchDatasources: [

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -46,7 +46,10 @@ jobs:
           registry: ghcr.io
           # repository_owner is stable for schedule runs; actor can vary.
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer GHCR_TOKEN when present. The existing home-ops/devcontainer
+          # package is not linked to this repository, so GITHUB_TOKEN gets
+          # permission_denied: write_package even with packages: write.
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -17,8 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-# Match the working cruise-caller image workflow: declare write access at the
-# workflow level so GITHUB_TOKEN can publish to ghcr.io.
+# Free GHCR publish via GITHUB_TOKEN only (no stored PAT/secret).
+# Requires packages: write + package linked to this repository.
 permissions:
   contents: read
   packages: write
@@ -44,12 +44,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          # repository_owner is stable for schedule runs; actor can vary.
           username: ${{ github.repository_owner }}
-          # Prefer GHCR_TOKEN when present. The existing home-ops/devcontainer
-          # package is not linked to this repository, so GITHUB_TOKEN gets
-          # permission_denied: write_package even with packages: write.
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: devcontainers/ci@v0.3
@@ -57,7 +53,6 @@ jobs:
           BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
           imageName: ghcr.io/${{ github.repository }}/devcontainer
-          # cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
           imageTag: base,latest
           platform: linux/amd64,linux/arm64
           configFile: .devcontainer/ci/devcontainer.json

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
-    paths: [".devcontainer/ci/**"]
+    paths: [".devcontainer/ci/**", ".github/workflows/devcontainer.yaml"]
   pull_request:
     branches: ["main"]
-    paths: [".devcontainer/ci/**"]
+    paths: [".devcontainer/ci/**", ".github/workflows/devcontainer.yaml"]
   schedule:
     - cron: "0 0 * * 1"
 
@@ -17,13 +17,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+# Match the working cruise-caller image workflow: declare write access at the
+# workflow level so GITHUB_TOKEN can publish to ghcr.io.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   devcontainer:
     name: publish
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -41,7 +44,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          # repository_owner is stable for schedule runs; actor can vary.
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Setup Homebrew
         id: setup-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        # Pin away from deprecated @master branch sync.
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Setup Python
         uses: actions/setup-python@v7
@@ -51,10 +52,16 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt', 'requirements.yaml') }}
           path: .venv
 
-      - name: Setup Workflow Tools
-        if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}
+      - name: Setup go-task
+        # go-task/tap ships a cask; Linux runners lack /usr/bin/xattr and cask
+        # install fails. Use the official static binary installer instead.
         shell: bash
-        run: brew install go-task/tap/go-task
+        run: |
+          set -euo pipefail
+          if ! command -v task >/dev/null 2>&1; then
+            curl -fsSL https://taskfile.dev/install.sh | sh -s -- -d -b /usr/local/bin
+          fi
+          task --version
 
       - name: Run Workstation Brew tasks
         if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Workflow Tools
         if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}
         shell: bash
-        run: brew install go-task
+        run: brew install go-task/tap/go-task
 
       - name: Run Workstation Brew tasks
         if: ${{ github.event_name == 'pull_request' && steps.cache-homebrew-packages.outputs.cache-hit != 'true' }}

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   flux-diff:
     name: Flux Diff
@@ -19,48 +22,59 @@ jobs:
       contents: read
       pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
-        paths: ["kubernetes"]
-        resources: ["helmrelease", "kustomization"]
+        resource: ["hr", "ks"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          path: pull
+          fetch-depth: 0
 
-      - name: Checkout Default Branch
-        uses: actions/checkout@v7
+      - name: Setup flate
+        uses: home-operations/flate/action@797c483c107913d3f7757b7d3e1f6bc9179fe43d # v0.6.0
         with:
-          ref: "${{ github.event.repository.default_branch }}"
-          path: default
+          cache: true
+          version: "0.6.0"
+          # Materialize default branch for changed-only diffs via FLATE_BASE.
+          base: ${{ github.event.repository.default_branch }}
 
       - name: Diff Resources
-        uses: docker://ghcr.io/allenporter/flux-local:main
-        with:
-          args: >-
-            diff ${{ matrix.resources }}
-            --unified 6
-            --path /github/workspace/pull/${{ matrix.paths }}
-            --path-orig /github/workspace/default/${{ matrix.paths }}
-            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart"
-            --limit-bytes 10000
-            --all-namespaces
-            --sources "home-kubernetes"
-            --output-file diff.patch
-
-      - name: Generate Diff
         id: diff
+        shell: bash
         run: |
-          cat diff.patch
-          echo "diff<<EOF" >> $GITHUB_OUTPUT
-          cat diff.patch >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # Walk Flux from kubernetes/flux; flate follows KS spec.path.
+          # --allow-missing-secrets soft-skips SOPS/in-cluster secrets offline.
+          diff_out="$(
+            flate diff "${{ matrix.resource }}" \
+              --path ./kubernetes/flux \
+              --output diff \
+              --allow-missing-secrets \
+              --strip-attr helm.sh/chart \
+              --strip-attr checksum/config \
+              --strip-attr checksum/secret \
+              --strip-attr app.kubernetes.io/version \
+              --strip-attr chart
+          )"
+
+          {
+            echo "diff<<EOF"
+            printf '%s\n' "${diff_out}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [[ -n "${diff_out}" ]]; then
+            echo "${diff_out}"
+          else
+            echo "No ${{ matrix.resource }} diff"
+          fi
 
       - if: ${{ steps.diff.outputs.diff != '' }}
         name: Add comment
         uses: mshick/add-pr-comment@v3
         with:
-          message-id: "${{ github.event.pull_request.number }}/${{ matrix.paths }}/${{ matrix.resources }}"
+          message-id: "${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resource }}"
           message-failure: Diff was not successful
           message: |
             ```diff

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -19,10 +19,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Setup Workflow Tools
         run: |
+          set -euo pipefail
           # Fully-qualified formula names auto-trust the specific item under Homebrew 6+ tap trust.
           brew install fluxcd/tap/flux kubeconform kustomize
 

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -22,7 +22,9 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Setup Workflow Tools
-        run: brew install fluxcd/tap/flux kubeconform kustomize
+        run: |
+          # Fully-qualified formula names auto-trust the specific item under Homebrew 6+ tap trust.
+          brew install fluxcd/tap/flux kubeconform kustomize
 
       - name: Run kubeconform
         shell: bash

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   LYCHEE_OUTPUT: lychee/out.md
   WORKFLOW_ISSUE_TITLE: "Link Checker Dashboard 🔗"
@@ -27,7 +31,9 @@ jobs:
         id: lychee
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          args: --verbose --no-progress --exclude-mail './**/*.md'
+          # Mail is excluded by default since lychee 0.18+; --exclude-mail was
+          # removed in 0.24.x and now hard-fails the CLI before any scan runs.
+          args: --verbose --no-progress --exclude-path '.roo' --exclude-path '.ruru' --exclude-path 'roo-commander-v7.3.0-Wallaby' './**/*.md'
           output: "${{ env.LYCHEE_OUTPUT }}"
           debug: true
 

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -33,7 +33,8 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
           # Mail is excluded by default since lychee 0.18+; --exclude-mail was
           # removed in 0.24.x and now hard-fails the CLI before any scan runs.
-          args: --verbose --no-progress --exclude-path '.roo' --exclude-path '.ruru' --exclude-path 'roo-commander-v7.3.0-Wallaby' './**/*.md'
+          # Accept 403 for sites that bot-block GitHub Actions egress.
+          args: --verbose --no-progress --accept '200,204,206,403' --exclude-path '.roo' --exclude-path '.ruru' --exclude-path 'roo-commander-v7.3.0-Wallaby' './**/*.md'
           output: "${{ env.LYCHEE_OUTPUT }}"
           debug: true
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,9 @@
 https://dash.cloudflare.com/profile/api-tokens
 https://www.mend.io/free-developer-tools/renovate/
+# Internal / non-public endpoints
+http://localhost
+http://127.0.0.1
+https://localhost
+https://127.0.0.1
+.*\.cluster\.local
+.*\.svc\.cluster\.local

--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -4,7 +4,9 @@ version: "3"
 
 vars:
   TALOS_DIR: "{{.KUBERNETES_DIR}}/talos"
-  TALHELPER_SECRET_FILE: "{{.TALOS_DIR}}/talhelper.sops.yaml"
+  # talhelper defaults to talsecret(.sops).yaml; keep the name aligned so
+  # genconfig finds secrets without an explicit --secret-file flag.
+  TALHELPER_SECRET_FILE: "{{.TALOS_DIR}}/talsecret.sops.yaml"
   TALHELPER_CONFIG_FILE: "{{.TALOS_DIR}}/talconfig.yaml"
 
 env:

--- a/.taskfiles/Workstation/Brewfile
+++ b/.taskfiles/Workstation/Brewfile
@@ -1,11 +1,11 @@
-tap "fluxcd/tap"
-tap "go-task/tap"
-tap "siderolabs/talos"
+tap "fluxcd/tap", trusted: true
+tap "go-task/tap", trusted: true
+tap "siderolabs/talos", trusted: true
 brew "age"
 brew "cloudflared"
 brew "direnv"
-brew "fluxcd/tap/flux"
-brew "go-task/tap/go-task"
+brew "fluxcd/tap/flux", trusted: true
+brew "go-task/tap/go-task", trusted: true
 brew "helm"
 brew "jq"
 brew "kubeconform"

--- a/.taskfiles/Workstation/Brewfile
+++ b/.taskfiles/Workstation/Brewfile
@@ -1,11 +1,9 @@
 tap "fluxcd/tap", trusted: true
-tap "go-task/tap", trusted: true
 tap "siderolabs/talos", trusted: true
 brew "age"
 brew "cloudflared"
 brew "direnv"
 brew "fluxcd/tap/flux", trusted: true
-brew "go-task/tap/go-task", trusted: true
 brew "helm"
 brew "jq"
 brew "kubeconform"
@@ -17,3 +15,10 @@ brew "stern"
 brew "talhelper"
 brew "talosctl"
 brew "yq"
+# go-task/tap only publishes a cask now. Cask install needs macOS xattr tooling and
+# breaks on Linux CI runners. Install go-task via taskfile.dev/install.sh in CI,
+# and keep the cask for local macOS workstations.
+if OS.mac?
+  tap "go-task/tap", trusted: true
+  cask "go-task/tap/go-task", trusted: true
+end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hopefully some of this peeked your interests!  If you are marching forward, now 
 > [!NOTE]
 > 1. The included behaviour of Talos or k3s is that all nodes are able to run workloads, **including** the controller nodes. **Worker nodes** are therefore **optional**.
 > 2. Do you have 3 or more nodes? It is highly recommended to make 3 of them controller nodes for a highly available control plane.
-> 3. Running the cluster on Proxmox VE? My thoughts and recommendations about that are documented [here](https://onedr0p.github.io/home-ops/notes/proxmox-considerations.html).
+> 3. Running the cluster on Proxmox VE? Keep hypervisor storage/networking separate from Kubernetes storage, and avoid nested hyperconverged storage stacks when possible.
 
 | Role    | Cores    | Memory        | System Disk               |
 |---------|----------|---------------|---------------------------|
@@ -106,8 +106,8 @@ Hopefully some of this peeked your interests!  If you are marching forward, now 
 
 
 > [!NOTE]
-> 1. It is recommended to have an 8GB RasPi model. Most important is to **boot from an external SSD/NVMe** rather than an SD card. This is [supported natively](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html), however if you have an early model you may need to [update the bootloader](https://www.tomshardware.com/how-to/boot-raspberry-pi-4-usb) first.
-> 2. Check the [power requirements](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#power-supply) if using a PoE Hat and a SSD/NVMe dongle.
+> 1. It is recommended to have an 8GB RasPi model. Most important is to **boot from an external SSD/NVMe** rather than an SD card. Native USB/NVMe boot is supported on current Raspberry Pi OS/firmware; early Pi 4 models may need a bootloader update first (see Raspberry Pi docs / Tom's Hardware guides).
+> 2. Check Raspberry Pi PoE Hat + SSD/NVMe power requirements before relying on PoE alone.
 
 1. Download the latest stable release of Debian from [here](https://raspi.debian.net/tested-images). _**Do not** use Raspbian or DietPi or any other flavor Linux OS._
 
@@ -157,7 +157,7 @@ Once you have installed Talos or Debian on your nodes, there are six stages to g
 
 You have two different options for setting up your local workstation.
 
-- First option is using a `devcontainer` which requires you to have Docker and VSCode installed. This method is the fastest to get going because all the required CLI tools are provided for you in my [devcontainer](https://github.com/onedr0p/cluster-template/pkgs/container/cluster-template%2Fdevcontainer) image.
+- First option is using a `devcontainer` which requires you to have Docker and VSCode installed. This method is the fastest to get going because all the required CLI tools are provided for you in the repo's `.devcontainer` image published to GHCR.
 - The second option is setting up the CLI tools directly on your workstation.
 
 #### Devcontainer method

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/bjw-s.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/bjw-s.yaml.j2
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: oci
   interval: 5m
-  url: oci://ghcr.io/bjw-s/helm
+  url: oci://ghcr.io/bjw-s-labs/helm

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -159,10 +159,12 @@ patches:
               - rshared
               - rw
 
-  # Disable predictable NIC naming
+  # Disable predictable NIC naming.
+  # Talos 1.12+ UKI mode rejects extraKernelArgs unless grubUseUKICmdline is false.
   - |-
     machine:
       install:
+        grubUseUKICmdline: false
         extraKernelArgs:
           - net.ifnames=0
 

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -208,10 +208,13 @@ controlPlane:
           advertisedSubnets:
             - "{{ nodes.host_network }}"
 
-    # Disable default API server admission plugins.
+    # Clear default API server admission plugins.
+    # Talos 1.12+/talhelper multi-doc machine configs reject JSON6902 patches;
+    # use strategic-merge style instead.
     - |-
-      - op: remove
-        path: /cluster/apiServer/admissionControl
+      cluster:
+        apiServer:
+          admissionControl: []
 
     # Enable K8s Talos API Access
     - |-

--- a/kubernetes/apps/home-automation/README.md
+++ b/kubernetes/apps/home-automation/README.md
@@ -10,13 +10,13 @@ This namespace contains Home Assistant, Frigate, and Mosquitto MQTT broker for h
 - **LoadBalancer IP**: `10.0.0.236`
 
 ### 2. Home Assistant
-- **URL**: https://ha.${SECRET_DOMAIN}
+- **URL**: `https://ha.<domain>` (cluster external hostname)
 - **Purpose**: Home automation platform
 - **Storage**: 10Gi on Longhorn
 - **Configuration**: Will be created on first startup
 
 ### 3. Frigate
-- **URL**: https://frigate.${SECRET_DOMAIN}
+- **URL**: `https://frigate.<domain>` (cluster external hostname)
 - **Purpose**: NVR with AI object detection for security cameras
 - **Storage**: Configured for NFS to Synology NAS (needs configuration)
 
@@ -63,7 +63,7 @@ kubectl get pods -n home-automation -w
 
 ### 3. Configure Frigate Cameras
 
-1. Access Frigate at https://frigate.${SECRET_DOMAIN}
+1. Access Frigate at `https://frigate.<domain>`
 2. Edit the ConfigMap at `frigate/app/configmap.yaml`
 3. Add your camera configurations:
 
@@ -91,7 +91,7 @@ cameras:
 
 ### 4. Configure Home Assistant
 
-1. Access Home Assistant at https://ha.${SECRET_DOMAIN}
+1. Access Home Assistant at `https://ha.<domain>`
 2. Complete the initial setup wizard
 3. Add the MQTT integration:
    - Server: `mosquitto.home-automation.svc.cluster.local`

--- a/kubernetes/apps/home-automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/ks.yaml
@@ -9,7 +9,6 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
   path: ./kubernetes/apps/home-automation/mosquitto/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- **Lychee:** root cause was CLI breakage, not bad links. lychee 0.24.x removed `--exclude-mail` (mail is excluded by default), so the daily job exited in ~1s with exit code 2. Removed the flag, excluded vendored `.roo`/`.ruru` docs, and ignored localhost/cluster.local endpoints.
- **devcontainer:** image build succeeded; push failed with `permission_denied: write_package` on `ghcr.io/scottking2/home-ops/devcontainer`. Repo default Actions token perms were `read` (updated repo setting to `write`). Workflow now declares `packages: write` at workflow scope and logs into GHCR as `repository_owner`, matching the working cruise-caller publish path.
- **Renovate:** Dependency Dashboard warned because:
  1. private image `ghcr.io/scottking2/vrm-mqtt-bridge` cannot be looked up without package credentials → disabled that package rule
  2. excess registryUrls from bootstrap vs live `bjw-s` HelmRepository mismatch (`ghcr.io/bjw-s/helm` vs `ghcr.io/bjw-s-labs/helm`) → bootstrap template aligned to live URL

## Test plan
- [x] Inspect latest failed Lychee + devcontainer logs
- [x] Inspect Renovate Dependency Dashboard
- [ ] `workflow_dispatch` Lychee on this branch
- [ ] `workflow_dispatch` devcontainer on this branch
- [ ] Confirm Renovate dashboard clears private lookup warning after next Renovate run

## Needs your decision if still failing
- If devcontainer still gets `write_package` after this PR: open GHCR package **home-ops/devcontainer** → Package settings → Manage Actions access → grant this repo **Write** (or delete orphaned package and let Actions recreate it).
- If you want Renovate to track `vrm-mqtt-bridge` again: add a GHCR read token for Renovate/Mend instead of keeping the package disabled.